### PR TITLE
bump golangci to 1.41.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Linters
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.40
+          version: v1.41.1
           working-directory: ${{ env.BRANCH }}
 
   tests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - dupl
     - durationcheck
     - errorlint
+    - exhaustive
     - exportloopref
     - funlen
     - gci
@@ -40,15 +41,18 @@ linters:
     - gofmt
     - gofumpt
     - goheader
-    - goimports
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ifshort
+    - importas
     - ineffassign
+    - lll
+    - makezero
     - misspell
     - nestif
+    - nilerr
     - noctx
     - nolintlint
     - prealloc
@@ -59,9 +63,12 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - tagliatelle
+    - thelper
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
+    - wastedassign
     - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,8 +41,6 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
-    - gomodguard
     - goprintffuncname
     - gosec
     - gosimple
@@ -55,6 +53,7 @@ linters:
     - nolintlint
     - prealloc
     - predeclared
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 [Инструкция по сдаче ДЗ](https://github.com/OtusGolang/home_work/wiki#%D0%A1%D1%82%D1%83%D0%B4%D0%B5%D0%BD%D1%82%D0%B0%D0%BC).
 
 ---
-Используемая версия [golangci-lint](https://golangci-lint.run/usage/install/#other-ci): <b>v1.40.0</b>
+Используемая версия [golangci-lint](https://golangci-lint.run/usage/install/#other-ci): <b>v1.41.1</b>
 ```
 $ golangci-lint version
-golangci-lint has version 1.40.0 built from 5c6adb6 on 2021-02-17T09:32:37Z
+golangci-lint has version 1.41.1 built from a2074809 on 2021-06-19T16:01:50Z
 ```
 
 ---

--- a/hw10_program_optimization/stats_optimization_test.go
+++ b/hw10_program_optimization/stats_optimization_test.go
@@ -20,6 +20,7 @@ const (
 // go test -v -count=1 -timeout=30s -tags bench .
 func TestGetDomainStat_Time_And_Memory(t *testing.T) {
 	bench := func(b *testing.B) {
+		b.Helper()
 		b.StopTimer()
 
 		r, err := zip.OpenReader("testdata/users.dat.zip")

--- a/hw12_13_14_15_calendar/Makefile
+++ b/hw12_13_14_15_calendar/Makefile
@@ -26,7 +26,7 @@ test:
 	go test -race ./internal/... ./pkg/...
 
 install-lint-deps:
-	(which golangci-lint > /dev/null) || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.37.0
+	(which golangci-lint > /dev/null) || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.41.1
 
 lint: install-lint-deps
 	golangci-lint run ./...


### PR DESCRIPTION
По пути нашёл багулю:
https://github.com/ryancurrah/gomodguard/issues/21